### PR TITLE
chore: migrate npm publishing to trusted publishers (OIDC)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,4 +1,3 @@
-# Inspired by: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry & https://pnpm.io/continuous-integration#github-actions
 name: Publish Superfluid Token List package to NPM
 on:
   workflow_dispatch:
@@ -11,17 +10,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-      # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:
-          node-version: "18.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
-          scope: "@superfluid-finance"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build package
-        run: pnpm --filter @superfluid-finance/tokenlist build 
+        run: pnpm --filter @superfluid-finance/tokenlist build
       - name: Publish package
         run: pnpm --filter @superfluid-finance/tokenlist publish --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}

--- a/packages/tokenlist/package.json
+++ b/packages/tokenlist/package.json
@@ -23,5 +23,10 @@
     "tsup": "^7.2.0"
   },
   "packageManager": "pnpm@8.6.1",
-  "sideEffects": false
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/superfluid-org/tokenlist.git",
+    "directory": "packages/tokenlist"
+  }
 }


### PR DESCRIPTION
## Summary
- Replace long-lived `NPMJS_TOKEN` secret with npm [Trusted Publishers](https://docs.npmjs.com/trusted-publishers) (OIDC-based auth from GitHub Actions)
- Upgrade Node.js 18 (EOL) → 24 in publish workflow
- Add `repository` field to `packages/tokenlist/package.json` (required for provenance attestation)

## Before merging
Configure the Trusted Publisher on npmjs.com:
1. Go to `@superfluid-finance/tokenlist` package Settings → Publishing access → Add Trusted Publisher → GitHub Actions
2. Organization: `superfluid-org`, Repository: `tokenlist`, Workflow: `npm-publish.yml`, Environment: *(blank)*

## After first successful publish
1. Revoke the old npm automation token
2. Remove the `NPMJS_TOKEN` secret from GitHub repo settings
3. Optionally set publishing access to "Require two-factor authentication and disallow tokens"

## Test plan
- [x] Configure Trusted Publisher on npmjs.com
- [x] Merge this PR
- [x] Trigger the `Publish Superfluid Token List package to NPM` workflow manually
- [x] Verify the publish succeeds and the package shows a provenance badge on npmjs.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)